### PR TITLE
ug2tex.py erlaubt jetzt 7-er, sus und D# Akkorde

### DIFF
--- a/Tools/ug2tex.py
+++ b/Tools/ug2tex.py
@@ -2,9 +2,12 @@
 # -*- coding: utf-8 -*-
 import sys, re
 
-legit_chords = ["A","B","H","C","C#","D","C#","E","F","F#","G","G#"]
+legit_chords = ["A","B","H","C","C#","D","D#","E","F","F#","G","G#"]
 legit_chords += [chord+"m" for chord in legit_chords]
-legit_chords += ["Cadd9","Dsus4","Dsus2"]
+legit_chords += [chord+"7" for chord in legit_chords]
+legit_chords += [chord+"sus2" for chord in legit_chords]
+legit_chords += [chord+"sus4" for chord in legit_chords]
+legit_chords += ["Cadd9"]
 
 def isChordLine(line):
     # criteria: more than half of the words are legit chords


### PR DESCRIPTION
in ug2tex.py gibt es eine Liste mit erlaubten Akkorden. Diese setzen sich aus den Grundtönen A bis G# und "Modifikatoren", hier "m" für Moll. Neu ist, dass 7-er Akkorde (z.B. H7) und alle sus-Akkorde (sus2 oder sus4) mit beliebigem Grundton unterstützt werden.

## Info:
Hallo, das ist mein erster pull request, insofern kann es sein, dass ich mich etwas ungeschickt anstelle. Ich arbeite an einem Programm, das das gleiche Zeil verfolgt, aber wesentlich umfangreicher ist, als ug2tex.py. Das möchte ich beitragen, wenn ich denke, dass es gut genug funktioniert. 
In ug2tex.py ist mir ein kleiner Fehler aufgefallen und da ich schon mal dabei war, habe ich die erlaubten Akkorde etwas offener gestaltet.
Gruß und gut Pfad
Paule
# Pull Requests

Thank you for contributing to Pfadiralala!

Please check your the following before submitting you pull request:

- [x] one song per pull request
- [x] if the song contains sheets, they are added as ABC source files
- [x] available metadata is correct
