### PR TITLE
Ziffern und Anführungszeichen im Text

### DIFF
--- a/Tools/txt2Latex/Beispiele/Skelett.tex
+++ b/Tools/txt2Latex/Beispiele/Skelett.tex
@@ -41,7 +41,7 @@ a\[G]lerdings o\[H]hne N\[Cm]ummer und mit m-Notation
 
 \beginchorus
 Da\[Esus2]s ist der Refrain. Der funktioniert wie alle Strophen auch.
-beachte: \dq Akk\[A]orde\dq  werden linksb\[B]ündig eingefügt, sowohl im Refrain, als auch in den Strophen.
+beachte: {\dq}Akk\[A]orde{\dq} werden linksb\[B]ündig eingefügt, sowohl im Refrain, als auch in den Strophen.
 \endchorus
 
 \beginverse

--- a/Tools/txt2Latex/lib/Heuristik/Heuristik.py
+++ b/Tools/txt2Latex/lib/Heuristik/Heuristik.py
@@ -2,12 +2,13 @@
 # Dieses Skript bestimmt die Warscheinlichkeit, dass eine Zeile eine Textzeile, überschrift, etc ist.
 import re
 from config.config import akkord_zeilen_regex, akkord_regex
+from config.metakeys import metakeys
 
 _typen = dict(Überschrift='Überschrift', Leer='Leer', Akkordzeile='Akkordzeile', Textzeile='Textzeile',
               Info='Info', none=None)
 
 # Alle attributnamen, die in der überschrift erlaubt sind.
-_Ueber_starts = set('ww wuw  jahr j  mel melodie weise  melj meljahr weisej weisejahr  txt worte text  txtj wortej wortejahr textj txtjahr textjahr alb album lager tonart key bo bock capo cp codex pf1 pfi pf  pf2 pfii  pf3 pfiii pf4 pfiiii pfiv pf4p pfiiiip pfivp ju jurten jurtenburg  gruen grün gruenes grünes  kss4 kssiv kssiiii  siru  biest  eg evg  egp evgp egplus evgplus tf turm turmfalke gb gnorken gnorkenbüdel'.split())
+_Ueber_starts = set(metakeys.keys())
 
 def Heuristik(zeilen):
     # Eingabe:  liste aus Strings, jeder string entspricht einer Zeile

--- a/Tools/txt2Latex/lib/Heuristik/Heuristik.py
+++ b/Tools/txt2Latex/lib/Heuristik/Heuristik.py
@@ -68,7 +68,7 @@ def p_Textzeile(line, lineNr, prev):
     if line.replace('\r', '').replace('\n', '') == '':
         return 0
     for zeichen in line:
-        if zeichen not in ' ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzÄÖÜäöüß.,-:;…–\'?!':
+        if zeichen not in ' 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzÄÖÜäöüß.,-:;…–\'?!':
             p_text *= 0.85                    # Textzeilen sollten nur text enthalten.
     p_text *= 0.85 ** line.count('  ')     # Doppelte leerzeichen deuten auf Akkordzeilen hin
     # Erlaube zwei Wiederholungszeichen (:|, |: oder :|:) pro zeile, bevor der die Warscheinlichkeit sinkt


### PR DESCRIPTION

Dieser Pull request enthält einige Verbesserungen, die mir bei der Arbeit mit meinem Liederbuch aufgefallen sind:

1. Jetzt sind mehrere Ziffern in Textzeilen erlaubt. Das löst ein Problem bei der erkennung der Zeilentypen, zum Beispiel beim Lied 500 Miles
2. Anführungszeichen serden jetzt typographisch richtig(er) gesetzt. Hier ging es hauptsächlich darum, die Leerzeichen in der Eingabedatei korrekt zu konvertieren.
3. wenn ich schon mal dabei war, habe ich den Code etwas aufgeräumt und einige Dopplungen entfernt, was änderungen an der Konfiguration minimal vereinfacht.